### PR TITLE
[Smartswitch] Adapt ENI Based forwarding design to FNIC

### DIFF
--- a/doc/smart-switch/high-availability/eni-based-forwarding.md
+++ b/doc/smart-switch/high-availability/eni-based-forwarding.md
@@ -48,6 +48,7 @@ This document provides a high-level design for Smart Switch ENI based Packet For
 | HA  | High Availability                                |
 | ENI  | Elastic Network Interface                      |
 | FNIC  | Floating NIC                      |
+| PL  | Private Link                      |
 
 ## Overview ##
 
@@ -91,16 +92,16 @@ ENI based forwarding requires the switch to understand the relationship between 
 * Each packet can be identified as belonging to that switch using VIP and VNI
 * Forwarding can be to local DPU or remote DPU over L3 VxLAN
 * Only support Floating NIC scenario
-* Scale for Floating NIC:
-    - [# of ENIs hosted] * 2 (with/without Tunnel Termination) + [# of ENIs not hosted] * 1 (without Tunnel Termination)
-* Scale Example for Floating NIC:
+* Scale for FNIC + PL:
+    - [# of ENIs hosted] * 2 (ER GW Bypass VNI + Private Link VNI) * 2 (with/without Tunnel Termination) + [# of ENIs not hosted] * 2 (ER GW Bypass VNI + Private Link VNI) * 1 (without Tunnel Termination)
+* Scale Example for FNIC + PL:
     - T1 per cluster: 8
     - DPU per T1: 4
     - ENI per DPU: 64
     - HA Scaling factor: 2
     - Total ENI's in this Cluster:  (8 * 4 * 64) / 2 = 1024
     - ENI's hosted on a T1: 256
-    - Number of ACL Rules:  256 * 2 + (1024 - 256) * 1 = 1280
+    - Number of ACL Rules:  256 * 2 * 2 + (1024 - 256) * 2 = 2560
 
 ### Phase 1 ###
 
@@ -164,7 +165,7 @@ VNET: Vnet1000
 
 Note:
 - outbound_eni_mac_lookup is not relevant for FNIC cases since we always match on INNER_DST_MAC
-- outbound_vni name is conceived based on VM NIC design, for FNIC same attribute is used to match all the packets related to this FNIC
+- TUNNEL_VNI is derived from the key of DASH_ENI_FORWARD_TABLE
 
 ```
 {  

--- a/doc/smart-switch/high-availability/eni-based-forwarding.md
+++ b/doc/smart-switch/high-availability/eni-based-forwarding.md
@@ -30,6 +30,7 @@
 | Rev | Date | Author | Change Description |
 | --- | ---- | ------ | ------------------ |
 | 0.1 | 10/05/2024 | Vivek Reddy Karri | Initial version |
+| 0.2 | 10/05/2025 | Vivek Reddy Karri | Floating NIC support |
 
 ## Scope ##
 
@@ -46,6 +47,7 @@ This document provides a high-level design for Smart Switch ENI based Packet For
 | NH  | Next Hop                                   |
 | HA  | High Availability                                |
 | ENI  | Elastic Network Interface                      |
+| FNIC  | Floating NIC                      |
 
 ## Overview ##
 
@@ -88,16 +90,17 @@ ENI based forwarding requires the switch to understand the relationship between 
 * Every ENI should be a part of T1 cluster
 * Each packet can be identified as belonging to that switch using VIP and VNI
 * Forwarding can be to local DPU or remote DPU over L3 VxLAN
-* Scale:
-    - [# of ENIs hosted] * 2 (inbound and outbound) * 2 (with/without Tunnel Termination) + [# of ENIs not hosted] * 2 (Inbound and outbound)
-* Scale Example:
+* Only support Floating NIC scenario
+* Scale for Floating NIC:
+    - [# of ENIs hosted] * 2 (with/without Tunnel Termination) + [# of ENIs not hosted] * 1 (without Tunnel Termination)
+* Scale Example for Floating NIC:
     - T1 per cluster: 8
     - DPU per T1: 4
     - ENI per DPU: 64
     - HA Scaling factor: 2
     - Total ENI's in this Cluster:  (8 * 4 * 64) / 2 = 1024
     - ENI's hosted on a T1: 256
-    - Number of ACL Rules:  256 * (2 * 2) + (1024 - 256) * 2 = 2560
+    - Number of ACL Rules:  256 * 2 + (1024 - 256) * 1 = 1280
 
 ### Phase 1 ###
 
@@ -106,7 +109,7 @@ ENI based forwarding requires the switch to understand the relationship between 
 - Orchagent should also program ACL Rules with Tunnel termination entries
 - No BFD sessions are created to local DPU or the remote DPU.
 
-DASH_ENI_FORWARD_TABLE schema is available here https://github.com/r12f/SONiC/blob/user/r12f/ha2/doc/smart-switch/high-availability/smart-switch-ha-detailed-design.md#2321-dash_eni_forward_table
+DASH_ENI_FORWARD_TABLE schema is available here https://github.com/sonic-net/SONiC/blob/master/doc/smart-switch/high-availability/smart-switch-ha-detailed-design.md#2321-dash_eni_forward_table
 
 ### Phase 2 ###
 
@@ -125,7 +128,6 @@ DASH_ENI_FORWARD_TABLE schema is available here https://github.com/r12f/SONiC/bl
                 "TUNNEL_VNI",
                 "DST_IP",
                 "DST_IPV6",
-                "INNER_SRC_MAC",
                 "INNER_DST_MAC",
                 "TUNNEL_TERM"
             ],
@@ -158,33 +160,18 @@ VIP: 1.1.1.1/32
 VNET: Vnet1000
 ```
 
-**ACL Rule for outbound traffic**
+**ACL Rule**
 
-MacDirection for outbound rules depends on the outbound_eni_mac_lookup field in the DASH_ENI_FORWARD_TABLE
+Note:
+- outbound_eni_mac_lookup is not relevant for FNIC cases since we always match on INNER_DST_MAC
+- outbound_vni name is conceived based on VM NIC design, for FNIC same attribute is used to match all the packets related to this FNIC
 
 ```
 {  
     "ACL_RULE": {
-        "ENI:Vnet1000_AABBCCDDEEFF_OUT": {
+        "ENI:Vnet1000_AABBCCDDEEFF": {
             "PRIORITY": "9997",
             "TUNNEL_VNI": "4000",
-            "DST_IP": "1.1.1.1/32",
-            "INNER_SRC_MAC/INNER_DST_MAC": "aa:bb:cc:dd:ee:ff"
-            "REDIRECT": "<local/tunnel nexthop>"
-        }
-    }
-}
-```
-
-**ACL Rule for inbound traffic**
-
-Inbound Traffic can have any ENI expect the outbound VNI, no need to match on TUNNEL_VNI
-
-```
-{  
-    "ACL_RULE": {
-        "ENI:Vnet1000_AABBCCDDEEFF_IN": {
-            "PRIORITY": "9996",
             "DST_IP": "1.1.1.1/32",
             "INNER_DST_MAC": "aa:bb:cc:dd:ee:ff"
             "REDIRECT": "<local/tunnel nexthop>"
@@ -207,30 +194,14 @@ To solve this, ACL rules with high priority are added and the redirect should al
 
 ![Tunnel Termination Solution](./images/tunn_term_solution.png)
 
-**ACL Rule for outbound traffic with Tunnel Termination**
+**ACL Rule with Tunnel Termination**
 
 ```
 {  
     "ACL_RULE": {
-        "ENI:Vnet1000_AABBCCDDEEFF_OUT_TERM": {
+        "ENI:Vnet1000_AABBCCDDEEFF_TERM": {
             "PRIORITY": "9999",
             "TUNNEL_VNI": "4000",
-            "DST_IP": "1.1.1.1/32",
-            "INNER_SRC_MAC/INNER_DST_MAC": "aa:bb:cc:dd:ee:ff",
-            "TUNN_TERM": "true",
-            "REDIRECT": "<local nexthop oid>"
-        }
-    }
-}
-```
-
-**ACL Rule for inbound traffic with Tunnel Termination**
-
-```
-{
-    "ACL_RULE": {
-        "ENI:Vnet1000_AABBCCDDEEFF_IN_TERM": {
-            "PRIORITY": "9998",
             "DST_IP": "1.1.1.1/32",
             "INNER_DST_MAC": "aa:bb:cc:dd:ee:ff",
             "TUNN_TERM": "true",

--- a/doc/smart-switch/high-availability/eni-based-forwarding.md
+++ b/doc/smart-switch/high-availability/eni-based-forwarding.md
@@ -101,7 +101,7 @@ ENI based forwarding requires the switch to understand the relationship between 
     - HA Scaling factor: 2
     - Total ENI's in this Cluster:  (8 * 4 * 64) / 2 = 1024
     - ENI's hosted on a T1: 256
-    - Number of ACL Rules:  256 * 2 + (1024 - 256) * 1 = 1280
+    - Number of ACL Rules:  256 * 2 + (1024 - 256) = 1280
 
 ### Phase 1 ###
 
@@ -165,6 +165,7 @@ VNET: Vnet1000
 Note:
 - outbound_eni_mac_lookup is not relevant for FNIC cases since we always match on INNER_DST_MAC
 - outbound_vni is not relevant for FNIC cases since we don't need to match on Tunnel VNI
+- VIP is common across the T1 cluster. It is not clear on where to consume it. It is currently read from a temporary config DB table "VIP_TABLE".
 
 ```
 {  

--- a/doc/smart-switch/high-availability/smart-switch-ha-detailed-design.md
+++ b/doc/smart-switch/high-availability/smart-switch-ha-detailed-design.md
@@ -570,10 +570,10 @@ When a HA set configuration on NPU side contains a local DPU, `hamgrd` will crea
 | DASH_ENI_FORWARD_TABLE | | | | |
 | | \<VNET_NAME\> | | VNET name. Used to correlate the VNET table to find VNET info, such as advertised VIP. | /{/{vnet_name/}/} |
 | | \<ENI_ID\> | | ENI ID. Same as the MAC address of the ENI. | /{/{eni_id/}/} |
-| | \<VNI\> | | Tunnel VNI of the arrived packet. Could be ER GW Bypass VNI, Private Link VNI or the VNET VNI | /{/{vni/}/} |
 | | | vdpu_ids | The list vDPU IDs hosting this ENI. | /{/{vdpu_id1/},/{vdpu_id2/},.../} |
 | | | primary_vdpu | The primary vDPU id. | /{/{dpu_id/}/} |
-| | | outbound_eni_mac_lookup | (Optional) Specify which MAC address to use to lookup the ENI for the outbound traffic. Not Relevant for Floating NIC | "none", "dst", "src" |
+| | | outbound_vni | (Optional) Outbound VNI used by this ENI, if different from the one in VNET. Each ENI can have its own VNI, such ExpressRoute Gateway Bypass case. | /{/{vni/}/} |
+| | | outbound_eni_mac_lookup | (Optional) Specify which MAC address to use to lookup the ENI for the outbound traffic. | "none", "dst", "src" |
 
 #### 2.3.3. CHASSIS_STATE_DB (per-NPU)
 

--- a/doc/smart-switch/high-availability/smart-switch-ha-detailed-design.md
+++ b/doc/smart-switch/high-availability/smart-switch-ha-detailed-design.md
@@ -570,10 +570,10 @@ When a HA set configuration on NPU side contains a local DPU, `hamgrd` will crea
 | DASH_ENI_FORWARD_TABLE | | | | |
 | | \<VNET_NAME\> | | VNET name. Used to correlate the VNET table to find VNET info, such as advertised VIP. | /{/{vnet_name/}/} |
 | | \<ENI_ID\> | | ENI ID. Same as the MAC address of the ENI. | /{/{eni_id/}/} |
+| | \<VNI\> | | Tunnel VNI of the arrived packet. Could be ER GW Bypass VNI, Private Link VNI or the VNET VNI | /{/{vni/}/} |
 | | | vdpu_ids | The list vDPU IDs hosting this ENI. | /{/{vdpu_id1/},/{vdpu_id2/},.../} |
 | | | primary_vdpu | The primary vDPU id. | /{/{dpu_id/}/} |
-| | | outbound_vni | (Optional) Outbound VNI used by this ENI, if different from the one in VNET. Each ENI can have its own VNI, such ExpressRoute Gateway Bypass case. | /{/{vni/}/} |
-| | | outbound_eni_mac_lookup | (Optional) Specify which MAC address to use to lookup the ENI for the outbound traffic. | "none", "dst", "src" |
+| | | outbound_eni_mac_lookup | (Optional) Specify which MAC address to use to lookup the ENI for the outbound traffic. Not Relevant for Floating NIC | "none", "dst", "src" |
 
 #### 2.3.3. CHASSIS_STATE_DB (per-NPU)
 


### PR DESCRIPTION
Update ENI based forwarding design to suite Floating NIC

- Only create ACL rules to match on INNER_DST_MAC
- Dont match on Tunnel VNI